### PR TITLE
Reset update

### DIFF
--- a/SoiUtils/interfaces.py
+++ b/SoiUtils/interfaces.py
@@ -1,0 +1,26 @@
+import abc
+
+class Resetable(metaclass=abc.ABCMeta):
+    @classmethod
+    def __subclasshook__(cls, __subclass: type) -> bool:
+        return hasattr(__subclass,'reset') and callable(__subclass.reset) or NotImplemented
+    
+    @abc.abstractmethod
+    def reset(self, *args,**kwargs):
+        """reset the object"""
+        raise NotImplementedError
+
+ 
+class Updatable(metaclass=abc.ABCMeta):
+    @classmethod
+    def __subclasshook__(cls, __subclass: type) -> bool:
+        return hasattr(__subclass,'update') and callable(__subclass.update) or NotImplemented
+    
+
+    @abc.abstractmethod
+    def update(*args,**kwargs):
+        raise NotImplementedError
+        
+    
+
+    

--- a/SoiUtils/interfaces.py
+++ b/SoiUtils/interfaces.py
@@ -6,7 +6,7 @@ class Resetable(metaclass=abc.ABCMeta):
         return hasattr(__subclass,'reset') and callable(__subclass.reset) or NotImplemented
     
     @abc.abstractmethod
-    def reset(self, *args,**kwargs):
+    def reset(self, *args,**kwargs) -> None:
         """reset the object"""
         raise NotImplementedError
 
@@ -17,8 +17,9 @@ class Updatable(metaclass=abc.ABCMeta):
         return hasattr(__subclass,'update') and callable(__subclass.update) or NotImplemented
     
 
-    @abc.abstractmethod
-    def update(*args,**kwargs):
+    @abc.abstractmethod 
+    def update(*args,**kwargs) -> None:
+        # update the object according to a new configuration
         raise NotImplementedError
         
     

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-VERSION = '0.1.5' 
+VERSION = '0.1.6' 
 DESCRIPTION = 'A Package that includes utility functions'
 LONG_DESCRIPTION = 'utils package that includes multiple utility functions that are used in different projects'
 


### PR DESCRIPTION
I created an interfaces.py file that will include generic interfaces.
Currently it includes.
Resetable - forces the class that will inherit from it to include a reset function
Updatable - forces the class that will inherit from it to include an update function
